### PR TITLE
Add per-zone fan curves for independent zone control

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A smart, automated fan control script for Supermicro servers with IPMI support. 
 
 - **Ultra-Quiet Operation**: Maintains 15% fan speed for normal temperatures (below 70°C)
 - **Temperature-Based Control**: Automatically adjusts fan speeds based on CPU temperature
-- **Dual-Zone Management**: Controls both CPU fans (Zone 0) and peripheral fans (Zone 1) independently
+- **Per-Zone Fan Curves**: Independent fan curves for CPU fans (Zone 0) and peripheral fans (Zone 1)
 - **Safety First**: Multiple safety mechanisms including emergency thresholds and automatic failover
 - **Systemd Integration**: Runs as a service with automatic startup
 - **Detailed Logging**: Comprehensive logs with automatic rotation
@@ -20,7 +20,7 @@ A smart, automated fan control script for Supermicro servers with IPMI support. 
 ## Software Requirements
 
 - `ipmitool` - IPMI management utility
-- `bash` - Shell scripting environment
+- `bash` 4.3 or later - Shell scripting environment
 - Root/sudo access
 
 ## Quick Start
@@ -76,31 +76,48 @@ sudo tail -f /var/log/fan-control.log
 
 ## Fan Curve Configuration
 
-### Current Default: Ultra-Quiet Profile
+The script supports **per-zone fan curves**, allowing independent speed profiles for CPU fans and peripheral/case fans. Both zones are driven by CPU temperature, but each can respond at different duty cycle levels.
 
-The script uses an ultra-quiet fan curve optimized for home/office environments:
+This is useful when case fans (Zone 1) are louder than CPU fans (Zone 0) and you want them to run at lower RPMs.
+
+### Default Curves
+
+**Zone 0 -- CPU fans (`CPU_FAN_CURVE`):**
 
 | Temperature Range | Fan Speed | Notes |
 |-------------------|-----------|-------|
-| < 70°C            | 15%       | Almost silent - normal operation |
+| < 70°C            | 15%       | Almost silent, normal operation |
 | 70-75°C           | 60%       | High load cooling |
 | 75-80°C           | 70%       | Very high load |
 | 80-85°C           | 80%       | Near emergency threshold |
 | 85-90°C           | 90%       | Critical temperatures |
-| ≥ 90°C            | 100%      | Maximum cooling |
+| >= 90°C           | 100%      | Maximum cooling |
 
-**Emergency Threshold**: 95°C (triggers 100% fan speed and safety shutdown)
+**Zone 1 -- Peripheral fans (`SYS_FAN_CURVE`):**
 
-### Customizing the Fan Curve
+| Temperature Range | Fan Speed | Notes |
+|-------------------|-----------|-------|
+| < 70°C            | 15%       | Almost silent, normal operation |
+| 70-75°C           | 45%       | Moderate cooling (quieter than CPU zone) |
+| 75-80°C           | 60%       | High load |
+| 80-85°C           | 75%       | Near emergency threshold |
+| 85-90°C           | 90%       | Critical temperatures |
+| >= 90°C           | 100%      | Maximum cooling |
 
-Edit the `FAN_CURVE` array in [supermicro-fan-control.sh](supermicro-fan-control.sh) (lines 41-55):
+**Emergency Threshold**: 95°C (triggers 100% fan speed on both zones and safety shutdown)
 
-#### Alternative: Balanced Profile
+> **Note:** Both zones use CPU temperature as their input. Supermicro X10/X11 boards do not expose per-zone temperature sensors through IPMI in a way that maps cleanly to peripheral devices, so CPU temperature drives both curves.
 
-For more gradual temperature response:
+### Customising the Fan Curves
+
+Edit `CPU_FAN_CURVE` and `SYS_FAN_CURVE` in [supermicro-fan-control.sh](supermicro-fan-control.sh):
+
+#### Example: Quieter Case Fans
+
+Keep CPU fans responsive while running case fans at minimal speed until temperatures are high:
 
 ```bash
-declare -A FAN_CURVE=(
+declare -A CPU_FAN_CURVE=(
     [0]=15      # Below 40°C: 15%
     [40]=20     # 40-50°C: 20%
     [50]=30     # 50-60°C: 30%
@@ -110,14 +127,33 @@ declare -A FAN_CURVE=(
     [80]=90     # 80-85°C: 90%
     [85]=100    # Above 85°C: 100%
 )
+
+declare -A SYS_FAN_CURVE=(
+    [0]=15      # Below 60°C: 15%
+    [60]=15     # 60-70°C: 15%
+    [70]=25     # 70-75°C: 25%
+    [75]=40     # 75-80°C: 40%
+    [80]=60     # 80-85°C: 60%
+    [85]=100    # Above 85°C: 100%
+)
 ```
 
-#### Alternative: Performance Profile
+#### Example: Performance Profile
 
-For maximum cooling and lower temperatures:
+For maximum cooling across both zones:
 
 ```bash
-declare -A FAN_CURVE=(
+declare -A CPU_FAN_CURVE=(
+    [0]=25      # Below 35°C: 25%
+    [35]=30     # 35-45°C: 30%
+    [45]=40     # 45-55°C: 40%
+    [55]=55     # 55-65°C: 55%
+    [65]=70     # 65-75°C: 70%
+    [75]=85     # 75-80°C: 85%
+    [80]=100    # Above 80°C: 100%
+)
+
+declare -A SYS_FAN_CURVE=(
     [0]=25      # Below 35°C: 25%
     [35]=30     # 35-45°C: 30%
     [45]=40     # 45-55°C: 40%
@@ -128,7 +164,14 @@ declare -A FAN_CURVE=(
 )
 ```
 
-After modifying the fan curve:
+### Backwards Compatibility
+
+If you are upgrading from a version that used a single `FAN_CURVE` variable, you have two options:
+
+1. **Migrate** (recommended): Copy your `FAN_CURVE` values to `CPU_FAN_CURVE`, then create a less aggressive `SYS_FAN_CURVE` for your case fans.
+2. **Keep the old variable**: If `FAN_CURVE` is defined in the script, it automatically overrides both `CPU_FAN_CURVE` and `SYS_FAN_CURVE`, so existing deployments continue to work without changes.
+
+After modifying the fan curves:
 
 ```bash
 sudo systemctl restart supermicro-fan-control.service
@@ -147,13 +190,15 @@ Edit [supermicro-fan-control.sh](supermicro-fan-control.sh) to customize:
 | `FAN_ZONES` | `(0 1)` | Fan zones to control |
 | `POLL_INTERVAL` | `10` | Temperature check interval (seconds) |
 | `EMERGENCY_TEMP` | `95` | Emergency shutdown temperature (°C) |
+| `CPU_FAN_CURVE` | Ultra-quiet profile | Fan curve for Zone 0 (CPU fans) |
+| `SYS_FAN_CURVE` | Quieter than CPU curve | Fan curve for Zone 1 (peripheral fans) |
 
 ## Safety Features
 
 1. **Emergency Threshold Protection**: If temps exceed 95°C, fans go to 100% and script exits to auto mode
-2. **Sensor Failure Protection**: If sensors fail to read, fans go to 100% and revert to auto mode
+2. **Sensor Failure Protection**: If sensors fail to read, fans revert to automatic BMC control (and set to 100% if auto mode restoration also fails)
 3. **Service Stop Safety**: When service stops, automatic fan control is restored
-4. **Dual-Zone Redundancy**: Both zones controlled independently for reliability
+4. **Per-Zone Safety**: Both zones enforce minimum speed and emergency thresholds independently
 5. **Conservative Design**: 15% minimum fan speed ensures adequate airflow at all times
 6. **Log Rotation**: Automatic log rotation prevents disk space issues
 
@@ -189,10 +234,14 @@ watch -n 2 'ipmitool sensor | grep -E "(Temp|FAN)"'
 
 ```
 [2025-11-12 10:30:00] [INFO] Starting main control loop (polling every 10 seconds)
-[2025-11-12 10:30:00] [INFO] Controlling Zone 0 (CPU fans) and Zone 1 (Peripheral fans) independently
-[2025-11-12 10:30:00] [INFO] Temperature: 45°C | Setting both zones: 15%
-[2025-11-12 10:31:00] [INFO] Temperature: 45°C | Both zones: 15% (stable)
-[2025-11-12 10:35:00] [INFO] Temperature: 72°C | Setting both zones: 60%
+[2025-11-12 10:30:00] [INFO] Controlling Zone 0 (CPU fans) and Zone 1 (Peripheral fans) with per-zone curves
+[2025-11-12 10:30:00] [INFO] Zone 0 (CPU) curve: 0°C:15% 35°C:15% ... 90°C:100%
+[2025-11-12 10:30:00] [INFO] Zone 1 (Peripheral) curve: 0°C:15% 35°C:15% ... 90°C:100%
+[2025-11-12 10:30:00] [INFO] Temperature: 45°C | Zone 0 (CPU): 0% -> 15%
+[2025-11-12 10:30:00] [INFO] Temperature: 45°C | Zone 1 (Peripheral): 0% -> 15%
+[2025-11-12 10:31:00] [INFO] Temperature: 45°C | Zone 0 (CPU): 15% | Zone 1 (Peripheral): 15% (stable)
+[2025-11-12 10:35:00] [INFO] Temperature: 72°C | Zone 0 (CPU): 15% -> 60%
+[2025-11-12 10:35:00] [INFO] Temperature: 72°C | Zone 1 (Peripheral): 15% -> 45%
 ```
 
 ## Manual IPMI Control
@@ -294,16 +343,16 @@ Common causes:
 
 ## Expected Noise Levels
 
-With the ultra-quiet default configuration:
+With the ultra-quiet default configuration (Zone 1 runs at lower duty than Zone 0 between 70-85°C):
 
-| Fan Speed | Noise Level | When It Occurs |
-|-----------|-------------|----------------|
-| 15% | Almost silent | Normal operation (< 70°C) |
-| 60% | Very loud | High load (70-75°C) |
-| 70% | Very loud | Very high load (75-80°C) |
-| 80% | Extremely loud | Near emergency (80-85°C) |
-| 90% | Extremely loud | Critical (85-90°C) |
-| 100% | Maximum | Emergency (≥ 90°C) |
+| Temperature | Zone 0 (CPU) | Zone 1 (Peripheral) | Noise Level |
+|-------------|-------------|---------------------|-------------|
+| < 70°C      | 15%         | 15%                 | Almost silent |
+| 70-75°C     | 60%         | 45%                 | Loud (CPU fans ramp first) |
+| 75-80°C     | 70%         | 60%                 | Very loud |
+| 80-85°C     | 80%         | 75%                 | Extremely loud |
+| 85-90°C     | 90%         | 90%                 | Extremely loud |
+| >= 90°C     | 100%        | 100%                | Maximum |
 
 ## Uninstalling
 
@@ -328,8 +377,8 @@ sudo ipmitool raw 0x30 0x01 0x01
 
 1. **Initialization**: Script enables manual fan control mode via IPMI
 2. **Monitoring**: Every 10 seconds (configurable), reads CPU temperatures from both CPUs
-3. **Calculation**: Uses the maximum temperature to determine required fan speed from the fan curve
-4. **Control**: Sends IPMI commands to set both fan zones to the calculated speed
+3. **Calculation**: Uses the maximum temperature to look up each zone's target duty from its fan curve
+4. **Control**: Sends IPMI commands to set each fan zone to its independently calculated speed
 5. **Safety**: Continuously monitors for emergency conditions and sensor failures
 6. **Cleanup**: On exit, returns fans to automatic IPMI control mode
 
@@ -337,7 +386,7 @@ sudo ipmitool raw 0x30 0x01 0x01
 
 - **Zone 0**: CPU fans (directly cooling processors)
 - **Zone 1**: Peripheral/System fans (case airflow)
-- **Control Strategy**: Both zones use the same fan curve for consistent airflow and noise levels
+- **Control Strategy**: Each zone uses its own fan curve; CPU fans can ramp independently of peripheral fans
 - **Temperature Source**: Maximum temperature from CPU1 and CPU2 sensors
 
 ## Contributing

--- a/supermicro-fan-control.sh
+++ b/supermicro-fan-control.sh
@@ -11,6 +11,12 @@
 
 set -euo pipefail
 
+# Require bash 4.3+ for associative array namerefs (local -n)
+if (( BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 3) )); then
+    echo "ERROR: bash 4.3 or later required (found ${BASH_VERSION})" >&2
+    exit 1
+fi
+
 ################################################################################
 # CONFIGURATION
 ################################################################################
@@ -34,11 +40,12 @@ POLL_INTERVAL=10
 # Set to 95°C (well below the 102°C high critical threshold for safety margin)
 EMERGENCY_TEMP=95
 
-# Fan curve: temperature -> duty cycle percentage
-# Applied to both Zone 0 (CPU fans) and Zone 1 (Peripheral fans)
-# Since fans are physically next to each other, use the same curve for both
+# Per-zone fan curves: temperature -> duty cycle percentage
+# Both zones use CPU temperature as input, but can respond at different levels
 # CPU safe operating range: 10-97°C (based on sensor thresholds)
-declare -A FAN_CURVE=(
+
+# Zone 0 (CPU fans: FAN1, FAN2, etc.)
+declare -A CPU_FAN_CURVE=(
     [0]=15      # Below 35°C: 15%
     [35]=15     # 35-40°C: 15%
     [40]=15     # 40-45°C: 15%
@@ -54,6 +61,29 @@ declare -A FAN_CURVE=(
     [90]=100    # Above 90°C: 100%
 )
 
+# Zone 1 (Peripheral/system fans: FANA, FANB, etc.)
+# Less aggressive than CPU fans by default to reduce case fan noise
+declare -A SYS_FAN_CURVE=(
+    [0]=15      # Below 35°C: 15%
+    [35]=15     # 35-40°C: 15%
+    [40]=15     # 40-45°C: 15%
+    [45]=15     # 45-50°C: 15%
+    [50]=15     # 50-55°C: 15%
+    [55]=15     # 55-60°C: 15%
+    [60]=15     # 60-65°C: 15%
+    [65]=15     # 65-70°C: 15%
+    [70]=45     # 70-75°C: 45%
+    [75]=60     # 75-80°C: 60%
+    [80]=75     # 80-85°C: 75%
+    [85]=90     # 85-90°C: 90%
+    [90]=100    # Above 90°C: 100%
+)
+
+# Backwards compatibility: if the legacy FAN_CURVE is defined (e.g. from an
+# older version of this script), it overrides both per-zone curves above.
+# To use per-zone curves, remove or comment out any FAN_CURVE definition.
+# declare -A FAN_CURVE=(...)
+
 # IPMI commands
 IPMI_ENABLE_MANUAL="0x30 0x45 0x01 0x01"
 IPMI_SET_FAN_ZONE="0x30 0x70 0x66 0x01"
@@ -68,6 +98,15 @@ CURRENT_CPU_DUTY=0
 CURRENT_PERIPHERAL_DUTY=0
 LAST_TEMP=0
 MANUAL_MODE_ACTIVE=false
+
+# Apply legacy FAN_CURVE if defined (backwards compatibility)
+if declare -p FAN_CURVE &>/dev/null; then
+    for _key in "${!FAN_CURVE[@]}"; do
+        CPU_FAN_CURVE[$_key]=${FAN_CURVE[$_key]}
+        SYS_FAN_CURVE[$_key]=${FAN_CURVE[$_key]}
+    done
+    unset _key
+fi
 
 ################################################################################
 # UTILITY FUNCTIONS
@@ -132,16 +171,19 @@ get_max_temp() {
     echo "${max_temp}"
 }
 
-# Calculate fan duty based on temperature using the fan curve
-# Used for both CPU and peripheral fans since they're physically adjacent
+# Calculate fan duty based on temperature using the specified fan curve
+# Pass the curve name (CPU_FAN_CURVE or SYS_FAN_CURVE) as second argument
 calculate_fan_duty() {
     local temp=$1
+    local -n _curve=$2
     local duty=15  # Default minimum
 
-    # Find appropriate duty cycle from fan curve
-    for threshold in $(echo "${!FAN_CURVE[@]}" | tr ' ' '\n' | sort -n); do
+    # Find appropriate duty cycle from fan curve (sorted thresholds)
+    local -a _sorted_keys
+    mapfile -t _sorted_keys < <(printf '%s\n' "${!_curve[@]}" | sort -n)
+    for threshold in "${_sorted_keys[@]}"; do
         if [[ ${temp} -ge ${threshold} ]]; then
-            duty=${FAN_CURVE[${threshold}]}
+            duty=${_curve[${threshold}]}
         fi
     done
 
@@ -172,7 +214,7 @@ enable_auto_mode() {
 
     # If that fails, set fans to 100% as a safety measure
     log "WARN" "Could not restore auto mode, setting fans to 100% for safety"
-    set_fan_duty 100
+    set_all_fans_duty 100
     return 1
 }
 
@@ -240,7 +282,7 @@ cleanup() {
 
     if ${MANUAL_MODE_ACTIVE}; then
         log "INFO" "Restoring automatic fan control mode"
-        enable_auto_mode
+        enable_auto_mode || true
     fi
 
     log "INFO" "Fan control script stopped"
@@ -318,7 +360,18 @@ preflight_checks() {
 
 main_loop() {
     log "INFO" "Starting main control loop (polling every ${POLL_INTERVAL} seconds)"
-    log "INFO" "Controlling Zone 0 (CPU fans) and Zone 1 (Peripheral fans) independently"
+    log "INFO" "Controlling Zone 0 (CPU fans) and Zone 1 (Peripheral fans) with per-zone curves"
+
+    # Log active fan curves at startup
+    local cpu_curve_str="" sys_curve_str=""
+    for _t in $(echo "${!CPU_FAN_CURVE[@]}" | tr ' ' '\n' | sort -n); do
+        cpu_curve_str+="${_t}°C:${CPU_FAN_CURVE[$_t]}% "
+    done
+    for _t in $(echo "${!SYS_FAN_CURVE[@]}" | tr ' ' '\n' | sort -n); do
+        sys_curve_str+="${_t}°C:${SYS_FAN_CURVE[$_t]}% "
+    done
+    log "INFO" "Zone 0 (CPU) curve: ${cpu_curve_str}"
+    log "INFO" "Zone 1 (Peripheral) curve: ${sys_curve_str}"
 
     while true; do
         # Get current maximum temperature
@@ -337,38 +390,39 @@ main_loop() {
             handle_emergency "${current_temp}"
         fi
 
-        # Calculate required fan duty (same for both zones)
-        local target_duty
-        target_duty=$(calculate_fan_duty "${current_temp}")
+        # Calculate per-zone target duties from their respective curves
+        local cpu_target sys_target
+        cpu_target=$(calculate_fan_duty "${current_temp}" CPU_FAN_CURVE)
+        sys_target=$(calculate_fan_duty "${current_temp}" SYS_FAN_CURVE)
 
-        # Track if any changes were made
         local changes_made=false
 
-        # Update both zones if needed (they use the same target duty)
-        if [[ ${target_duty} -ne ${CURRENT_CPU_DUTY} ]] || [[ ${target_duty} -ne ${CURRENT_PERIPHERAL_DUTY} ]]; then
-            log "INFO" "Temperature: ${current_temp}°C | Setting both zones: ${target_duty}%"
-
-            # Update Zone 0 (CPU fans)
-            if ! set_fan_duty_zone 0 "${target_duty}"; then
+        # Update Zone 0 (CPU fans) if duty has changed
+        if [[ ${cpu_target} -ne ${CURRENT_CPU_DUTY} ]]; then
+            log "INFO" "Temperature: ${current_temp}°C | Zone 0 (CPU): ${CURRENT_CPU_DUTY}% -> ${cpu_target}%"
+            if ! set_fan_duty_zone 0 "${cpu_target}"; then
                 log "ERROR" "Failed to set CPU fan duty - reverting to auto mode for safety"
                 enable_auto_mode
                 exit 1
             fi
+            changes_made=true
+        fi
 
-            # Update Zone 1 (Peripheral fans)
-            if ! set_fan_duty_zone 1 "${target_duty}"; then
+        # Update Zone 1 (Peripheral fans) if duty has changed
+        if [[ ${sys_target} -ne ${CURRENT_PERIPHERAL_DUTY} ]]; then
+            log "INFO" "Temperature: ${current_temp}°C | Zone 1 (Peripheral): ${CURRENT_PERIPHERAL_DUTY}% -> ${sys_target}%"
+            if ! set_fan_duty_zone 1 "${sys_target}"; then
                 log "ERROR" "Failed to set Peripheral fan duty - reverting to auto mode for safety"
                 enable_auto_mode
                 exit 1
             fi
-
             changes_made=true
         fi
 
-        # Log status if no changes (only every 6 cycles to reduce spam)
+        # Periodic stable status log (roughly every 60 seconds)
         if ! ${changes_made}; then
             if [[ $(($(date +%s) % 60)) -lt ${POLL_INTERVAL} ]]; then
-                log "INFO" "Temperature: ${current_temp}°C | Both zones: ${target_duty}% (stable)"
+                log "INFO" "Temperature: ${current_temp}°C | Zone 0 (CPU): ${cpu_target}% | Zone 1 (Peripheral): ${sys_target}% (stable)"
             fi
         fi
 


### PR DESCRIPTION
## Summary

- Replaces single `FAN_CURVE` with `CPU_FAN_CURVE` (Zone 0) and `SYS_FAN_CURVE` (Zone 1) for independent fan speed profiles
- `SYS_FAN_CURVE` defaults to less aggressive duty cycles (e.g. 45% vs 60% at 70-75°C) to reduce case fan noise
- Backwards compatible: if legacy `FAN_CURVE` is defined, it automatically overrides both per-zone curves

Closes #1

## Changes

**Script:**
- Per-zone fan curves with independent duty calculation per polling cycle
- Bash 4.3+ version guard (required for `local -n` nameref used to pass curve arrays)
- `calculate_fan_duty` accepts curve name as parameter via nameref, uses `mapfile`+`printf` for safer key sorting under `set -euo pipefail`
- Per-zone logging: shows `old% -> new%` transitions per zone, dumps active curves at startup
- Fixed bug: `set_fan_duty` (undefined) corrected to `set_all_fans_duty` in `enable_auto_mode` safety fallback
- Cleanup handler uses `enable_auto_mode || true` to prevent `set -e` from aborting shutdown

**README:**
- Per-zone fan curve documentation with both zone tables and example configs
- Backwards compatibility migration guide
- Updated noise level table showing both zones side-by-side
- Updated example log output, architecture, and safety feature descriptions

## Test plan

- [ ] Verify script starts and logs both curves at startup
- [ ] Confirm Zone 0 and Zone 1 receive different duty cycles at the same temperature (e.g. 72°C should give Zone 0: 60%, Zone 1: 45%)
- [ ] Test backwards compatibility: uncomment `FAN_CURVE`, verify both zones use its values
- [ ] Test emergency threshold: both zones should hit 100% at 95°C+
- [ ] Test sensor failure: script should revert to auto mode
- [ ] Verify bash version guard rejects bash < 4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)